### PR TITLE
Fix material-design-lite version in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Gixx/mdl-components-ext/issues"
   },
   "dependencies": {
-    "material-design-lite": "3.0.0",
+    "material-design-lite": "1.3.0",
     "node-sass": "4.5.3",
     "uglify-js": "3.1.3"
   }


### PR DESCRIPTION
Referring to issue #13